### PR TITLE
[PL-3656] Add extra options for ffprobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ require 'streamio-ffmpeg'
 
 ### Reading Metadata
 
+You can pass options to ffprobe through `FFMPEG::Movie`, so that the ffprobe command executed has the setting you want to. Example: `movie = FFMPEG::Movie.new("path/to/movie.mp4", { ffprobe_options: ["-read_intervals", "%+0.1", "-show_frames"] })`
+
 ``` ruby
 movie = FFMPEG::Movie.new("path/to/movie.mov")
 
@@ -69,6 +71,7 @@ movie.audio_streams[0] # "aac, 44100 Hz, stereo, s16, 75 kb/s" (raw audio stream
 
 movie.valid? # true (would be false if ffmpeg fails to read the movie)
 ```
+
 
 ### Transcoding
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -28,9 +28,9 @@ module FFMPEG
       end
 
       @path = path
-
+      ffprobe_options = options[:ffprobe_options] || [] # ffprobe_options needs to be sent as an array of string
       # ffmpeg will output to stderr
-      command = [FFMPEG.ffprobe_binary, '-i', path, *%w(-print_format json -show_format -show_streams -show_error)]
+      command = [FFMPEG.ffprobe_binary, '-i', path, *ffprobe_options, *%w(-print_format json -show_format -show_streams -show_error)].compact
       std_output = ''
       std_error = ''
 
@@ -145,6 +145,14 @@ module FFMPEG
       end
     end
 
+    def audio_frames
+      metadata[:frames].select { |f| f[:media_type] == "audio" }
+    end
+
+    def video_frames
+      metadata[:frames].select { |f| f[:media_type] == "video" }
+    end
+
     def valid?
       not @invalid
     end
@@ -155,6 +163,18 @@ module FFMPEG
 
     def local?
       not remote?
+    end
+
+    def frames
+      metadata[:frames] || []
+    end
+
+    def packets_and_frames
+      metadata[:packets_and_frames] || []
+    end
+
+    def packets
+      metadata[:packets] || []
     end
 
     def width


### PR DESCRIPTION
Add the ability to pass options to the initial `ffprobe` command